### PR TITLE
Sort events by their start date

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @events = Event.all
+    @events = Event.recent_first.all
     respond_with @events
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,8 @@ class Event < ActiveRecord::Base
   validates :title, :slug, :presence => true
   validates :slug, :uniqueness => { :case_sensitive => false }
 
+  scope :recent_first, order("start_date desc")
+
   def to_param
     self.slug
   end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -3,6 +3,7 @@
 
   <%= f.inputs do %>
     <%= f.input :title %>
+    <%= f.input :start_date, :as => :string %>
     <%= f.input :slug, ( resource.persisted? ? { :input_html => { :disabled => true } } : { } ) %>
     <%= f.input :secret, :label => "Event secret", :input_html => { :placeholder => "If blank, projects must create their own passwords"} %>
     <%= f.input :url, :label => "Event homepage", :input_html => { :placeholder => "http://" } %>

--- a/db/migrate/20130204184500_add_start_date_to_events.rb
+++ b/db/migrate/20130204184500_add_start_date_to_events.rb
@@ -1,0 +1,5 @@
+class AddStartDateToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120811120439) do
+ActiveRecord::Schema.define(:version => 20130204184500) do
 
   create_table "admins", :force => true do |t|
     t.string    "email",                  :default => "", :null => false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(:version => 20120811120439) do
     t.boolean   "use_centres",             :default => false
     t.string    "url"
     t.boolean   "enable_project_creation", :default => true
+    t.date      "start_date"
   end
 
   create_table "projects", :force => true do |t|

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -35,6 +35,7 @@ describe Admin::EventsController do
           @valid_attributes = {
             :title => "Example Event",
             :secret => nil,
+            :start_date => "1 January 2013",
             :award_categories_attributes => [
               { :title => "Best in Show", :format => "overall", :level => "1" }
             ]
@@ -45,6 +46,7 @@ describe Admin::EventsController do
           post :create, :event => @valid_attributes
           assigns(:event).should be_persisted
           assigns(:event).title.should == "Example Event"
+          assigns(:event).start_date.should == Date.parse("1 January 2013")
         end
 
         it "should redirect to the event list" do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,6 +1,32 @@
 require 'spec_helper'
 
 describe EventsController do
+  describe "GET index" do
+    before do
+      @events = [
+        FactoryGirl.create(:event, :title => "Event One", :start_date => Date.parse("1 January 2013")),
+        FactoryGirl.create(:event, :title => "Event Two", :start_date => Date.parse("3 January 2013")),
+        FactoryGirl.create(:event, :title => "Event Three", :start_date => Date.parse("2 January 2013"))
+      ]
+    end
+
+    it "should be successful" do
+      get :index
+      response.should be_success
+    end
+
+    it "assigns a collection of all the events" do
+      get :index
+      assigns(:events).should =~ @events
+    end
+
+    it "loads the most recent events first" do
+      get :index
+
+      assigns(:events).map(&:title).should == ["Event Two", "Event Three", "Event One"]
+    end
+  end
+
   context "given an event exists" do
     before do
       @event = FactoryGirl.create(:event_without_secret)

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     sequence(:title) {|n| "Hack all the things ##{n}"}
     sequence(:slug) {|n| "hack-everything-#{n}"}
     secret "secret"
+    start_date { Date.today }
 
     factory :event_without_secret do
       secret nil

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,7 +7,8 @@ describe Event do
       @valid_attributes = {
         :title => "Event Title",
         :slug => "event-slug",
-        :secret => "secret"
+        :secret => "secret",
+        :start_date => Date.parse("1 January 2013")
       }
     end
 


### PR DESCRIPTION
As requested by @adamamyl in issue #1 

This adds the start_date field to an event. Right now, this is only used to sort the events in descending order in the events list on the root page.
